### PR TITLE
Linkify job description to create new lines

### DIFF
--- a/app/pods/components/job/job-row/template.hbs
+++ b/app/pods/components/job/job-row/template.hbs
@@ -27,7 +27,7 @@
     <li>
         <p class="event-summary mt2">
           <span class="bold">Descripción:</span>
-          {{ item.description }}
+          {{{ linkify-text item.description }}}
         </p>
         <p class="event-summary mt2">
           <span class="bold">Cómo contactar:</span>


### PR DESCRIPTION
Fixes when a job description has new lines as `\n` it should create a new html line with `br` as it happens with event descriptions.